### PR TITLE
implemented -p|--plaintext option which prints e-mail without styling

### DIFF
--- a/_examples/output/main.go
+++ b/_examples/output/main.go
@@ -4,9 +4,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/liamg/guerrilla/pkg/guerrilla"
-
 	"github.com/liamg/guerrilla/internal/app/output"
+	"github.com/liamg/guerrilla/pkg/guerrilla"
 )
 
 func main() {

--- a/internal/app/cmd/root.go
+++ b/internal/app/cmd/root.go
@@ -5,10 +5,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/liamg/guerrilla/internal/app/output"
-
+	"github.com/liamg/guerrilla/internal/app/printer"
 	"github.com/liamg/guerrilla/pkg/guerrilla"
-
 	"github.com/spf13/cobra"
 )
 
@@ -16,6 +14,10 @@ var rootCmd = &cobra.Command{
 	Use:   "guerrilla",
 	Short: "Guerrilla is a command line tool for creating a temporary email address and receiving associated email in the terminal. Powered by the Guerrilla Mail API.",
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		var (
+			mailPrinter printer.Printer
+		)
 
 		cmd.SilenceUsage = true
 		cmd.SilenceErrors = true
@@ -29,9 +31,16 @@ var rootCmd = &cobra.Command{
 			return fmt.Errorf("poll-interval must be between 1-600")
 		}
 
-		printer := output.New(cmd.OutOrStdout())
+		genericPrinter := printer.NewGuerrillaPrinter(cmd.OutOrStdout())
+		mailPrinter = func() printer.Printer {
+			if plaintext {
+				return printer.NewPlaintextPrinter(cmd.OutOrStdout())
+			}
 
-		printer.PrintSummary(client.GetAddress())
+			return genericPrinter
+		}()
+
+		genericPrinter.PrintSummary(client.GetAddress())
 
 		poller := guerrilla.NewPoller(client, guerrilla.PollOptionWithInterval(time.Second*time.Duration(flagPollIntervalSeconds)))
 		var count int
@@ -39,7 +48,7 @@ var rootCmd = &cobra.Command{
 			if !showWelcomeEmail && count == 0 && email.Subject == "Welcome to Guerrilla Mail" {
 				continue
 			}
-			printer.PrintEmail(email)
+			mailPrinter.PrintEmail(email)
 			count++
 		}
 
@@ -49,13 +58,16 @@ var rootCmd = &cobra.Command{
 
 var (
 	flagPollIntervalSeconds int
-	showWelcomeEmail        bool
+
+	plaintext        bool
+	showWelcomeEmail bool
 )
 
 func Execute() {
 
 	rootCmd.Flags().IntVarP(&flagPollIntervalSeconds, "poll-interval", "i", 30, "Poll interval in seconds. Must be between 1-600. Low values are not recommended due to API rate limits.")
 	rootCmd.Flags().BoolVarP(&showWelcomeEmail, "show-welcome", "w", false, "Show the default GuerrillaMail welcome email in the output (filtered by default).")
+	rootCmd.Flags().BoolVarP(&plaintext, "plaintext", "p", false, "Wether print e-mails in plaintext (useful for copying).")
 
 	if err := rootCmd.Execute(); err != nil {
 		_, _ = fmt.Fprintln(os.Stderr, err)

--- a/internal/app/printer/guerrilla.go
+++ b/internal/app/printer/guerrilla.go
@@ -1,0 +1,252 @@
+package printer
+
+import (
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/liamg/guerrilla/pkg/guerrilla"
+	"github.com/liamg/tml"
+	"github.com/mattn/go-runewidth"
+	"golang.org/x/term"
+)
+
+const (
+	borderTopLeft     = '╭'
+	borderTopRight    = '╮'
+	borderBottomLeft  = '╰'
+	borderBottomRight = '╯'
+	borderVertical    = '│'
+	borderHorizontal  = '─'
+	borderLeftT       = '├'
+	borderRightT      = '┤'
+)
+
+type guerrillaPrinter struct {
+	w     io.Writer
+	width int
+}
+
+func NewGuerrillaPrinter(w io.Writer) GuerrillaPrinter {
+
+	width, _, err := term.GetSize(0)
+	if err != nil {
+		width = 80
+	}
+
+	return &guerrillaPrinter{
+		w:     w,
+		width: width,
+	}
+}
+
+var _ Printer = (*guerrillaPrinter)(nil)
+
+func (p *guerrillaPrinter) printf(format string, args ...interface{}) {
+	_ = tml.Fprintf(p.w, format, args...)
+}
+
+func (p *guerrillaPrinter) printHeader(heading string) {
+	p.printf(
+		"\r\n<dim>%c%c%c</dim> <bold>%s</bold> <dim>%c%s%c</dim>\n",
+		borderTopLeft,
+		borderHorizontal,
+		borderRightT,
+		heading,
+		borderLeftT,
+		safeRepeat(string(borderHorizontal), p.width-7-runewidth.StringWidth(heading)),
+		borderTopRight,
+	)
+	p.printBlank()
+}
+
+func (p *guerrillaPrinter) printDivider(heading string) {
+	p.printBlank()
+	p.printf(
+		"<dim>%c%c%c</dim> <bold>%s</bold> <dim>%c%s%c</dim>\n",
+		borderLeftT,
+		borderHorizontal,
+		borderRightT,
+		heading,
+		borderLeftT,
+		safeRepeat(string(borderHorizontal), p.width-7-runewidth.StringWidth(heading)),
+		borderRightT,
+	)
+	p.printBlank()
+}
+
+func safeRepeat(input string, repeat int) string {
+	if repeat <= 0 {
+		return ""
+	}
+	return strings.Repeat(input, repeat)
+}
+
+func (p *guerrillaPrinter) printIn(indent int, strip bool, format string, args ...interface{}) {
+
+	var lines []string
+	if strip {
+		lines = p.limitSizeWithStrip(fmt.Sprintf(format, args...), p.width-indent-4)
+	} else {
+		lines = p.limitSize(fmt.Sprintf(format, args...), p.width-indent-4)
+	}
+
+	for _, line := range lines {
+		realStr := line
+		if strip {
+			realStr = stripTags(line)
+		}
+		repeat := p.width - 4 - indent - runewidth.StringWidth(realStr)
+		coloured := line
+		if strip {
+			coloured = tml.Sprintf(line)
+		}
+		padded := coloured + safeRepeat(" ", repeat)
+		p.printf("<dim>%c</dim> %s", borderVertical, safeRepeat(" ", indent))
+		p.printf("%s", padded)
+		p.printf(" <dim>%c</dim>\n", borderVertical)
+	}
+}
+
+func (p *guerrillaPrinter) limitSizeWithStrip(input string, size int) []string {
+	var word string
+	var words []string
+	var inTag bool
+	for _, r := range []rune(input) {
+		if inTag {
+			word += string(r)
+			if r == '>' {
+				inTag = false
+				if word != "" {
+					words = append(words, word)
+				}
+				word = ""
+			}
+		} else {
+			if r == '<' {
+				if word != "" {
+					words = append(words, word)
+				}
+				word = "<"
+				inTag = true
+			} else if r == ' ' {
+				if word != "" {
+					words = append(words, word)
+					word = ""
+				} else {
+					words[len(words)-1] += " "
+				}
+			} else if r == '\n' {
+				if word != "" {
+					words = append(words, word)
+					word = ""
+				}
+				words = append(words, "\n")
+			} else {
+				word += string(r)
+			}
+		}
+	}
+	if word != "" {
+		words = append(words, word)
+	}
+
+	var line string
+	var currentSize int
+	var lines []string
+	var hasContent bool
+
+	for _, word := range words {
+		if word == "\n" {
+			lines = append(lines, line)
+			line = ""
+			continue
+		}
+		if word[0] == '<' {
+			line += word
+			continue
+		}
+		if currentSize+runewidth.StringWidth(word)+1 > size {
+			lines = append(lines, line)
+			line = word
+			hasContent = true
+			currentSize = runewidth.StringWidth(word)
+		} else {
+			if line != "" && hasContent {
+				line += " "
+				currentSize++
+			}
+			line += word
+			hasContent = true
+			currentSize += runewidth.StringWidth(word)
+		}
+	}
+
+	if line != "" {
+		lines = append(lines, line)
+	}
+
+	if len(lines) == 0 {
+		return []string{""}
+	}
+
+	return lines
+}
+
+func (p *guerrillaPrinter) limitSize(input string, max int) []string {
+	lines := strings.Split(input, "\n")
+	var output []string
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		for runewidth.StringWidth(line) > max {
+			output = append(output, line[:max])
+			line = line[max:]
+		}
+		until := max
+		if until > len(line) {
+			until = len(line)
+		}
+		output = append(output, line[:until])
+	}
+	return output
+}
+
+func (p *guerrillaPrinter) printBlank() {
+	p.printIn(0, true, "")
+}
+
+func (p *guerrillaPrinter) printFooter() {
+	p.printBlank()
+	p.printf("<dim>%c%s%c</dim>\n", borderBottomLeft, safeRepeat(string(borderHorizontal), p.width-2), borderBottomRight)
+}
+
+var rgxHtml = regexp.MustCompile(`<[^>]+>`)
+
+func stripTags(input string) string {
+	return rgxHtml.ReplaceAllString(input, "")
+}
+
+func (p *guerrillaPrinter) PrintSummary(address string) {
+	p.printHeader("New Address Created")
+	p.printIn(0, true, "Your disposable email address is:")
+	p.printIn(0, true, "")
+	p.printIn(4, true, "<blue>%s</blue>", address)
+	p.printIn(0, true, "")
+	p.printIn(0, true, "Emails will appear below as they are received.")
+	p.printFooter()
+}
+
+func (p *guerrillaPrinter) PrintEmail(email guerrilla.Email) {
+	p.printHeader("Email #" + email.ID)
+	p.printIn(0, true, "Subject:       <blue>%s", email.Subject)
+	p.printIn(0, true, "From:          <blue>%s", email.From)
+	p.printIn(0, true, "Time:          <blue>%s", email.Timestamp.Format(time.RFC1123))
+	p.printIn(0, true, "ContentType:   <blue>%s", email.ContentType)
+	p.printIn(0, true, "RefMid:        <blue>%s", email.RefMid)
+	p.printIn(0, true, "Size:          <blue>%d", email.Size)
+	p.printDivider("Body")
+	p.printIn(0, false, "%s", email.Body)
+	p.printFooter()
+}

--- a/internal/app/printer/plaintext.go
+++ b/internal/app/printer/plaintext.go
@@ -1,0 +1,34 @@
+package printer
+
+import (
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/liamg/guerrilla/pkg/guerrilla"
+)
+
+type plaintextPrinter struct {
+	w io.Writer
+}
+
+func NewPlaintextPrinter(w io.Writer) Printer {
+	return &plaintextPrinter{
+		w: w,
+	}
+}
+
+func (p *plaintextPrinter) PrintEmail(email guerrilla.Email) {
+
+	fmt.Println("Email #" + email.ID)
+
+	fmt.Printf("Subject:       %s\n", email.Subject)
+	fmt.Printf("From:          %s\n", email.From)
+	fmt.Printf("Time:          %s\n", email.Timestamp.Format(time.RFC1123))
+	fmt.Printf("ContentType:   %s\n", email.ContentType)
+	fmt.Printf("RefMid:        %s\n", email.RefMid)
+	fmt.Printf("Size:          %d\n", email.Size)
+	fmt.Println("")
+
+	fmt.Println(email.Body)
+}

--- a/internal/app/printer/printer.go
+++ b/internal/app/printer/printer.go
@@ -1,0 +1,12 @@
+package printer
+
+import "github.com/liamg/guerrilla/pkg/guerrilla"
+
+type Printer interface {
+	PrintEmail(email guerrilla.Email)
+}
+
+type GuerrillaPrinter interface {
+	Printer
+	PrintSummary(address string)
+}


### PR DESCRIPTION
## Motivation

you would rather like to copy HTML based e-mail from terminal for further processing, so it should be raw thing.

## More ideas

it might be useful to specifically support file output, e.g., when `stdout` is redirected to file, it goes plaintext and doesn't contain `summary` part.
